### PR TITLE
Add ability to copy an existing sbt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ object Main {
 - `--no-cache` - Disables caching will recreate every time.
 - `--compile-only` - Does not execute the resulting executable. (Useful to confirm compilation)
 - `--sbt-output` - Puts the produced sbt project in this location rather than a temporary directory. (This is editor compliant and should allow you to debug with editor support and then bring your findings back to a script.)
+- `--sbt-file` - Allows you to specify a `Build.sbt` file location to use with the script. this will ignore script headers.
 
 ### VSCode Highlighting
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val Scala213 = "2.13.5"
 
-ThisBuild / crossScalaVersions := Seq(Scala213, "3.0.0-RC3")
+ThisBuild / crossScalaVersions := Seq(Scala213, "3.0.0-RC2")
 ThisBuild / scalaVersion := crossScalaVersions.value.last
 
 ThisBuild / githubWorkflowArtifactUpload := false
@@ -61,7 +61,7 @@ ThisBuild / githubWorkflowPublish := Seq(
 
 val catsV = "2.6.0"
 val catsEffectV = "3.1.0"
-val fs2V = "3.0.2"
+val fs2V = "3.0.1"
 
 val munitCatsEffectV = "1.0.2"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val Scala213 = "2.13.5"
 
-ThisBuild / crossScalaVersions := Seq(Scala213, "3.0.0-RC2")
+ThisBuild / crossScalaVersions := Seq(Scala213, "3.0.0-RC3")
 ThisBuild / scalaVersion := crossScalaVersions.value.last
 
 ThisBuild / githubWorkflowArtifactUpload := false
@@ -61,7 +61,7 @@ ThisBuild / githubWorkflowPublish := Seq(
 
 val catsV = "2.6.0"
 val catsEffectV = "3.1.0"
-val fs2V = "3.0.1"
+val fs2V = "3.0.2"
 
 val munitCatsEffectV = "1.0.2"
 

--- a/core/src/main/scala/io/chrisdavenport/catscript/Main.scala
+++ b/core/src/main/scala/io/chrisdavenport/catscript/Main.scala
@@ -80,7 +80,7 @@ object Command {
               if (args.verbose) console.println(s"SBT Project Output: $tempFolder") 
               else Applicative[F].unit
             } >>
-              Files.createInFolder(tempFolder, config, parsed._2, args.sbtFile.map(Paths.get(_))) >>
+            Files.createInFolder(tempFolder, config, parsed._2, args.sbtFile.map(Paths.get(_))) >>
             Files.stageExecutable(tempFolder) >> {
               if (args.compileOnly) Applicative[F].unit
               else
@@ -103,7 +103,7 @@ object Command {
               if (args.verbose) console.println(s"SBT Project Output: $tempFolder") 
               else Applicative[F].unit
             } >>
-              Files.createInFolder(tempFolder, config, parsed._2, args.sbtFile.map(Paths.get(_))) >>
+            Files.createInFolder(tempFolder, config, parsed._2, args.sbtFile.map(Paths.get(_))) >>
             Files.stageExecutable[F](tempFolder) >>
             fs2.Stream(fileContentSha).through(fs2.text.utf8Encode)
               .through(fs2.io.file.Files[F].writeAll(stageDir.resolve("script_sha")))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("io.chrisdavenport" % "sbt-no-publish" % "0.1.0")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.5")
 addSbtPlugin("com.codecommit" % "sbt-github-actions" % "0.9.5")
 
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.16")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.20")
 addSbtPlugin("com.47deg" % "sbt-microsites" % "1.3.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")
 


### PR DESCRIPTION
I find myself using the same dependencies across many scripts.

this PR introduces a flag to specify a `build.sbt` file. catScript will copy the file to the temp directory. Header Options are ignored as a result.